### PR TITLE
Bugfixes

### DIFF
--- a/src/routes/code/RepoInfoCard.svelte
+++ b/src/routes/code/RepoInfoCard.svelte
@@ -34,7 +34,7 @@
 
 <Card href={url} class="repo-card flex h-min w-[360px] max-w-[360px] flex-col">
   <div class="flex flex-row items-center justify-between">
-    <Heading tag={compact ? 'h6' : 'h4'}>{name}</Heading>
+    <Heading class="tracking-wider" tag={compact ? 'h6' : 'h4'}>{name}</Heading>
     <div
       class="flex flex-row items-center gap-2 text-lg font-bold"
       class:text-sm={compact}

--- a/src/routes/resume/+page.svelte
+++ b/src/routes/resume/+page.svelte
@@ -29,8 +29,10 @@
     ><PrinterSolid /></button
   >
   <Tooltip>Print Page</Tooltip>
-  <a href={pdf} class={`${pdf ? '' : 'hidden'} mr-2 text-sm text-gray-700 dark:text-gray-400`}
-    ><DownloadSolid /></a
+  <a
+    href={pdf}
+    class={`${pdf ? '' : 'hidden'} mr-2 text-sm text-gray-700 dark:text-gray-400`}
+    download><DownloadSolid /></a
   >
   <Tooltip>Download PDF {RESUME_LABEL}</Tooltip>
 </div>


### PR DESCRIPTION
- Make RepoInfoCard headers more legible
- Retry GH repo fetch without auth instead of crashing Code page (public repo data can be fetched without auth, but we were not falling back after 401/unauthorized)
- Fix Download Resume button - previously would download resume, but then confuse the SvelteKit router